### PR TITLE
Print in milliseconds

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -21,7 +21,7 @@ t0 = time.time()
 C = f(A, B)
 elapsed = time.time() - t0
 
-print(f"{elapsed} sec")
+print(f"{elapsed * 1000} msec")
 
 err = np.sum((C - gt) ** 2)
 


### PR DESCRIPTION
In benchmark script, print the runtime in milliseconds instead of seconds